### PR TITLE
Add Github Actions Build & Release

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -1,0 +1,53 @@
+name: Cross-Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        goos: ['windows', 'darwin']
+        go: ['1.13']
+    name: Build
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+    
+    - name: Print Go version and environment
+      id: vars
+      run: |
+        printf "Using go at: $(which go)\n"
+        printf "Go version: $(go version)\n"
+        printf "\n\nGo environment:\n\n"
+        go env
+        printf "\n\nSystem environment:\n\n"
+        env
+        echo "::set-output name=go_cache::$(go env GOCACHE)"
+        
+    - name: Checkout code into the Go module directory
+      uses: actions/checkout@v2
+      
+    - name: Run Build
+      env:
+        CGO_ENABLED: 0
+        GOOS: ${{ matrix.goos }}
+      shell: bash
+      continue-on-error: true
+      working-directory: .
+      run: |
+        GOOS=$GOOS go build 2> /dev/null
+        if [ $? -ne 0 ]; then
+          echo "::warning ::$GOOS Build Failed"
+          exit 0
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Release
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        go: [ '1.13' ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    # So GoReleaser can generate the changelog properly
+    - name: Unshallowify the repo clone
+      run: git fetch --prune --unshallow
+
+    # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+    - name: Print Go version and environment
+      id: vars
+      run: |
+        printf "Using go at: $(which go)\n"
+        printf "Go version: $(go version)\n"
+        printf "\n\nGo environment:\n\n"
+        go env
+        printf "\n\nSystem environment:\n\n"
+        env
+        echo "::set-output name=version_tag::${GITHUB_REF/refs\/tags\//}"
+        echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+        echo "::set-output name=go_cache::$(go env GOCACHE)"
+
+        # Parse semver
+        TAG=${GITHUB_REF/refs\/tags\//}
+        SEMVER_RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z\.-]*\)'
+        TAG_MAJOR=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\1#"`
+        TAG_MINOR=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\2#"`
+        TAG_PATCH=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\3#"`
+        TAG_SPECIAL=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\4#"`
+        echo "::set-output name=tag_major::${TAG_MAJOR}"
+        echo "::set-output name=tag_minor::${TAG_MINOR}"
+        echo "::set-output name=tag_patch::${TAG_PATCH}"
+        echo "::set-output name=tag_special::${TAG_SPECIAL}"
+
+    - name: Cache the build cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.vars.outputs.go_cache }}
+        key: ${{ runner.os }}-go${{ matrix.go }}-release-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go${{ matrix.go }}-release
+
+    # GoReleaser will take care of publishing those artifacts into the release
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ steps.vars.outputs.version_tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 goose
 *.swp
 *.test
+*.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+builds:
+- id: "goose-sqlite"
+  env:
+  - CGO_ENABLED=0
+  main: .
+  binary: goose-sqlite
+  goarch:
+  - amd64
+  goos:
+  - windows
+  - darwin
+  ldflags:
+  - -s -w
+
+archives:
+- files:
+  format_overrides:
+    - goos: windows
+      format: zip
+  replacements:
+      darwin: mac
+
+checksum:
+  algorithm: sha512
+
+nfpms:
+  - id: default
+    package_name: goose-sqlite
+
+    vendor: SteelSeries ApS
+    homepage: https://steelseries.com
+    description: |
+      Goose-sqlite. From the now-defunct bitbucket.org/dastels/goose-sqlite
+    license: MIT
+
+release:
+  github:
+    owner: SteelSeries
+    name: goose-sqlite
+
+changelog:
+  sort: asc

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/steelseries/goose-sqlite
+
+go 1.13
+
+require (
+	github.com/erh/go-gypsy v0.0.0-20130315034859-9505fa93c871
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/erh/go-gypsy v0.0.0-20130315034859-9505fa93c871 h1:YoSDfp7vpfUZWUr4hS9BFFEuXm6ecmwvHbxzoyW59/Q=
+github.com/erh/go-gypsy v0.0.0-20130315034859-9505fa93c871/go.mod h1:PqUiUsnUGTASJvz5WTgnpQRT/VJxC5P9SCdl02vONVM=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=


### PR DESCRIPTION
This will add two workflows:
1. cross-build - This will trigger on pull requests and pushes into master, it will validate that we can build both a windows and darwin version of goose-sqlite
2. release - This will trigger on a tag creation, it will use that tag and build a windows and mac release and push the release to Github automatically.