### PR TITLE
Allow for Direct Parameters for DB Path, DB Migration Path, and DB Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 goose
 *.swp
 *.test
+*.exe

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -46,7 +46,11 @@ func statusRun(cmd *Command, args ...string) {
 		log.Fatal(e)
 	}
 
-	fmt.Printf("goose: status for environment '%v'\n", conf.Env)
+	if conf.Env != "" {
+		fmt.Printf("goose: status for environment '%v'\n", conf.Env)
+	} else {
+		fmt.Printf("goose: status for DB '%v'\n", conf.OpenStr)
+	}
 	fmt.Println("    Applied At                  Migration")
 	fmt.Println("    =======================================")
 	for _, m := range mm.Migrations {

--- a/dbconf.go
+++ b/dbconf.go
@@ -11,8 +11,13 @@ import (
 )
 
 // global options. available to any subcommands.
-var dbPath = flag.String("path", "db", "folder containing db info")
+var dbConfPath = flag.String("path", "db", "folder containing db info")
 var dbEnv = flag.String("env", "development", "which DB environment to use")
+
+// Manual goose-sqlite command without configuration file
+var dbPath = flag.String("dbPath", "", "path to db file")
+var dbMigrationPath = flag.String("dbMigration", "", "path to db migrations")
+var dbDriver = flag.String("dbDriver", "", "the sql driver to use")
 
 type DBConf struct {
 	MigrationsDir string
@@ -23,8 +28,17 @@ type DBConf struct {
 
 // extract configuration details from the given file
 func MakeDBConf() (*DBConf, error) {
+	// Check to see if dbPath, dbMigrationPath, dbDriver were provided
+	if *dbPath != "" && *dbMigrationPath != "" && *dbDriver != "" {
+		return &DBConf{
+			MigrationsDir: *dbMigrationPath,
+			Env:           "",
+			Driver:        *dbDriver,
+			OpenStr:       *dbPath,
+		}, nil
+	}
 
-	cfgFile := filepath.Join(*dbPath, "dbconf.yml")
+	cfgFile := filepath.Join(*dbConfPath, "dbconf.yml")
 
 	f, err := yaml.ReadFile(cfgFile)
 	if err != nil {
@@ -45,7 +59,7 @@ func MakeDBConf() (*DBConf, error) {
 	// Automatically parse postgres urls
 
 	return &DBConf{
-		MigrationsDir: filepath.Join(*dbPath, "migrations"),
+		MigrationsDir: filepath.Join(*dbConfPath, "migrations"),
 		Env:           *dbEnv,
 		Driver:        drv,
 		OpenStr:       open,

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/steelseries/goose-sqlite
+
+go 1.13
+
+require (
+	github.com/erh/go-gypsy v0.0.0-20130315034859-9505fa93c871
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/erh/go-gypsy v0.0.0-20130315034859-9505fa93c871 h1:YoSDfp7vpfUZWUr4hS9BFFEuXm6ecmwvHbxzoyW59/Q=
+github.com/erh/go-gypsy v0.0.0-20130315034859-9505fa93c871/go.mod h1:PqUiUsnUGTASJvz5WTgnpQRT/VJxC5P9SCdl02vONVM=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=

--- a/migrate.go
+++ b/migrate.go
@@ -75,8 +75,13 @@ func runMigrations(conf *DBConf, migrationsDir string, target int64, allowOutOfO
 		mm.Sort(current < target)
 	}
 
-	fmt.Printf("goose: migrating db environment '%v', current version: %d, target: %d\n",
-		conf.Env, current, target)
+	if conf.Env != "" {
+		fmt.Printf("goose: migrating db environment '%v', current version: %d, target: %d\n",
+			conf.Env, current, target)
+	} else {
+		fmt.Printf("goose: migrating db '%v', current version: %d, target: %d\n",
+			conf.OpenStr, current, target)
+	}
 
 	for _, m := range mm.Migrations {
 		var e error


### PR DESCRIPTION
You can now use goose-sqlite without a `dbconf.yml`, like the following example:
```powershell
.\goose-sqlite.exe --dbPath=".\db\database.db" --dbMigration=".\db\migrations" --dbDriver="sqlite3" up
```

Only thing I am not as sure about it adding the `sqlite3` library as a mod dependency?